### PR TITLE
Shuffle package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "type": "git",
     "url": "https://github.com/transposit/transposit-js-sdk.git"
   },
-  "files": ["dist/**/*"],
   "browser": "dist/bundle.prod.js",
   "types": "dist/types",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,15 +1,19 @@
 {
   "name": "transposit",
   "version": "0.7.5",
-  "description": "Library for building apps on top of Transposit",
-  "main": "dist/bundle.dev.js",
-  "types": "dist/src/index.d.ts",
   "author": "Transposit",
+  "description": "SDK for web apps using Transposit as a backend",
+  "keywords": ["transposit", "sdk", "js", "ts", "api", "composition"],
   "license": "Apache-2.0",
+  "homepage": "https://github.com/transposit/transposit-js-sdk",
+  "bugs": "https://github.com/transposit/transposit-js-sdk/issues",
   "repository": {
     "type": "git",
-    "url": "git@github.com:transposit/transposit-js-sdk.git"
+    "url": "https://github.com/transposit/transposit-js-sdk.git"
   },
+  "files": ["dist/**/*"],
+  "browser": "dist/bundle.prod.js",
+  "types": "dist/types",
   "scripts": {
     "start": "yarn run build:dev --progress --watch",
     "build": "npm-run-all --parallel build:dev build:prod",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,18 +2,19 @@
   "compilerOptions": {
     "allowJs": false,
     "allowSyntheticDefaultImports": true,
-    "module": "esnext",
-    "moduleResolution": "Node",
-    "lib": ["es6", "dom"],
     "strictNullChecks": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "sourceMap": true,
+    "moduleResolution": "Node",
+    "lib": ["es6", "dom"],
     "target": "es5",
-    "declaration": true
+    "module": "esnext",
+    "declaration": true,
+    "outDir": "types",
+    "sourceMap": true,
   },
   "include": ["./src"]
 }


### PR DESCRIPTION
I wanted to clean up our `package.json` file to reference our now-public Git repository.

Along the way I started thinking about how we publish to npm. Specifically:
- I changed `main` to `browser` since our bundles are normally loaded by `<script>` tags.
- I added a `"declaration": true,` to our tsconfig so that declaration files are emitted in _dist/_ as well. They are in a _dist/types/_ directory. I point to them using the `types` key in package.json.
- I shuffled some key orders to group similar things together.

Here's what _dist/_ looks like after running `yarn run build`.
```
tree dist/
dist/
├── bundle.dev.js
├── bundle.dev.map
├── bundle.prod.js
├── bundle.prod.map
└── types
    ├── EndRequestLog.d.ts
    ├── Transposit.d.ts
    ├── __tests__
    │   └── Transposit.test.d.ts
    ├── index.d.ts
    └── test
        └── test-setup.d.ts

3 directories, 9 files
```
