### PR TITLE
TR-3549 errors in javascript console have dead links

### DIFF
--- a/src/Transposit.ts
+++ b/src/Transposit.ts
@@ -52,7 +52,7 @@ export class Transposit {
   constructor(
     private serviceMaintainer: string,
     private serviceName: string,
-    private tpsHostedAppApiUrl: string = "https://api.transposit.com",
+    private tpsHostedAppApiUrl: string = "https://console.transposit.com",
   ) {}
 
   private getConsumeKey(): string {

--- a/src/__tests__/Transposit.test.ts
+++ b/src/__tests__/Transposit.test.ts
@@ -32,7 +32,7 @@ describe("Transposit", () => {
   });
 
   const jplaceArbysClaims: any = Object.freeze({
-    iss: "https://api.transposit.com",
+    iss: "https://console.transposit.com",
     sub: "jplace@transposit.com",
     exp: 1522255319,
     iat: 1521650519,
@@ -49,10 +49,10 @@ describe("Transposit", () => {
       const transposit: Transposit = new Transposit("jplace", "arbys_beef");
 
       expect(transposit.getGoogleLoginLocation("https://altoids.com")).toEqual(
-        "https://api.transposit.com/app/jplace/arbys_beef/login/accounts?redirectUri=https%3A%2F%2Faltoids.com",
+        "https://console.transposit.com/app/jplace/arbys_beef/login/accounts?redirectUri=https%3A%2F%2Faltoids.com",
       );
       expect(transposit.startLoginUri("https://altoids.com")).toEqual(
-        "https://api.transposit.com/app/jplace/arbys_beef/login/accounts?redirectUri=https%3A%2F%2Faltoids.com",
+        "https://console.transposit.com/app/jplace/arbys_beef/login/accounts?redirectUri=https%3A%2F%2Faltoids.com",
       );
     });
 
@@ -111,7 +111,7 @@ describe("Transposit", () => {
         ),
       ).toEqual(jplaceArbysClaims);
       expect(window.location.href).toEqual(
-        "https://api.transposit.com/app/jplace/arbys_beef/connect?redirectUri=http%3A%2F%2Flocalhost%2F",
+        "https://console.transposit.com/app/jplace/arbys_beef/connect?redirectUri=http%3A%2F%2Flocalhost%2F",
       );
     });
 


### PR DESCRIPTION
### Issue
```
Experienced an error running an operation! View the debug logs here:
https://api.transposit.com/t/ahl/caltest/monitor/39de74cb-fef9-4ade-83ca-7c3ebbba6efe
```
This should be 'console.transposit.com' not 'api.transposit.com'

### Solution
- Changed `api.transposit.com` to be `console.transposit.com`