### PR TITLE
[WIP] Cache client claims, prefer throwing over returning null

### DIFF
--- a/src/Transposit.ts
+++ b/src/Transposit.ts
@@ -143,6 +143,11 @@ export class Transposit {
         "clientJwt query parameter does not appear to be a valid JWT string. This method should only be called after redirection during login.",
       );
     }
+    if (!this.checkClaimsValid(claims)) {
+      throw new Error(
+        "clientJwt query parameter does not appear to be a valid JWT string. clientJwt is expired.",
+      );
+    }
 
     // Persist claims. Login has succeeded.
 

--- a/src/Transposit.ts
+++ b/src/Transposit.ts
@@ -31,57 +31,17 @@ export interface OperationParameters {
   [paramName: string]: string;
 }
 
-// From https://stackoverflow.com/questions/901115/how-can-i-get-query-string-values-in-javascript
-function getParameterByName(name: string): string | null {
-  const url = window.location.href;
-  name = name.replace(/[\[\]]/g, "\\$&");
-  const regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)");
-  const results = regex.exec(url);
-  if (!results) {
-    return null;
-  }
-  if (!results[2]) {
-    return "";
-  }
-  return decodeURIComponent(results[2].replace(/\+/g, " "));
-}
-
 export const TRANSPOSIT_CONSUME_KEY_PREFIX = "TRANSPOSIT_CONSUME_KEY";
 
 export class Transposit {
+  private claims: ClientClaims | null = null;
+
   constructor(
     private serviceMaintainer: string,
     private serviceName: string,
     private tpsHostedAppApiUrl: string = "https://api.transposit.com",
-  ) {}
-
-  private getConsumeKey(): string {
-    return `${TRANSPOSIT_CONSUME_KEY_PREFIX}/${this.serviceMaintainer}/${
-      this.serviceName
-    }`;
-  }
-
-  private retrieveClientClaims(): ClientClaims | null {
-    const clientClaimJSON = localStorage.getItem(this.getConsumeKey());
-    if (!clientClaimJSON) {
-      return null;
-    }
-
-    return JSON.parse(clientClaimJSON);
-  }
-
-  private areClientClaimsValid(clientClaims: ClientClaims): boolean {
-    const expiration = clientClaims.exp * 1000;
-    const now = Date.now();
-    return expiration > now;
-  }
-
-  private persistClientClaims(clientClaimsJSON: string): void {
-    localStorage.setItem(this.getConsumeKey(), clientClaimsJSON);
-  }
-
-  private clearClientClaims(): void {
-    localStorage.removeItem(this.getConsumeKey());
+  ) {
+    this.claims = this.loadClaims();
   }
 
   private apiUrl(relativePath: string = ""): string {
@@ -90,26 +50,76 @@ export class Transposit {
     }${relativePath}`;
   }
 
+  private getConsumeKey(): string {
+    return `${TRANSPOSIT_CONSUME_KEY_PREFIX}/${this.serviceMaintainer}/${
+      this.serviceName
+    }`;
+  }
+
+  private loadClaims(): ClientClaims | null {
+    const claimsJSON = localStorage.getItem(this.getConsumeKey());
+    if (!claimsJSON) {
+      return null;
+    }
+
+    let claims: ClientClaims;
+    try {
+      claims = JSON.parse(claimsJSON);
+    } catch (err) {
+      return null;
+    }
+
+    if (!this.checkClaimsValid(claims)) {
+      return null;
+    }
+
+    return claims;
+  }
+
+  private persistClaims(claimsJSON: string): void {
+    localStorage.setItem(this.getConsumeKey(), claimsJSON);
+  }
+
+  private clearClaims(): void {
+    localStorage.removeItem(this.getConsumeKey());
+  }
+
+  private checkClaimsValid(claims: ClientClaims): boolean {
+    const expiration = claims.exp * 1000;
+    const now = Date.now();
+    return expiration > now;
+  }
+
+  private assertLoggedIn(): void {
+    if (this.claims === null) {
+      throw new Error("No client claims found.");
+    }
+  }
+
+  isLoggedIn(): boolean {
+    return this.claims !== null;
+  }
+
   handleLogin(callback?: (info: { needsKeys: boolean }) => void): void {
     // Read query parameters
 
-    const maybeClientJwtString = getParameterByName("clientJwt");
-    if (maybeClientJwtString === null) {
+    const searchParams = new URLSearchParams(window.location.search);
+
+    if (!searchParams.has("clientJwt")) {
       throw new Error(
         "clientJwt query parameter could not be found. This method should only be called after redirection during login.",
       );
     }
-    const clientJwtString = maybeClientJwtString;
+    const clientJwtString = searchParams.get("clientJwt")!;
 
-    const maybeNeedsKeys = getParameterByName("needsKeys");
-    if (maybeNeedsKeys === null) {
+    if (!searchParams.has("needsKeys")) {
       throw new Error(
         "needsKeys query parameter could not be found. This is unexpected.",
       );
     }
-    const needsKeys = maybeNeedsKeys === "true";
+    const needsKeys = searchParams.get("needsKeys")! === "true";
 
-    // Parse JWT string and persist claims
+    // Parse JWT string
 
     const jwtParts: string[] = clientJwtString.split(".");
     if (jwtParts.length !== 3) {
@@ -117,25 +127,29 @@ export class Transposit {
         "clientJwt query parameter does not appear to be a valid JWT string. This method should only be called after redirection during login.",
       );
     }
-    let clientClaimsJSON: string;
+    let claimsJSON: string;
     try {
-      clientClaimsJSON = atob(jwtParts[1]);
+      claimsJSON = atob(jwtParts[1]);
     } catch (err) {
       throw new Error(
         "clientJwt query parameter does not appear to be a valid JWT string. This method should only be called after redirection during login.",
       );
     }
+    let claims: ClientClaims;
     try {
-      JSON.parse(clientClaimsJSON); // validate JSON
+      claims = JSON.parse(claimsJSON);
     } catch (err) {
       throw new Error(
         "clientJwt query parameter does not appear to be a valid JWT string. This method should only be called after redirection during login.",
       );
     }
 
-    this.persistClientClaims(clientClaimsJSON);
+    // Persist claims. Login has succeeded.
 
-    // Login has succeeded, either callback or default path replacement
+    this.claims = claims;
+    this.persistClaims(claimsJSON);
+
+    // Perform callback or default path replacement
 
     if (callback) {
       if (typeof callback !== "function") {
@@ -161,8 +175,7 @@ export class Transposit {
   }
 
   async logOut(): Promise<void> {
-    const clientClaims = this.retrieveClientClaims();
-    if (!clientClaims) {
+    if (!this.claims) {
       // Already logged out, nothing to do
       return;
     }
@@ -174,15 +187,16 @@ export class Transposit {
         method: "POST",
         headers: {
           "content-type": "application/json",
-          "X-PUBLIC-TOKEN": clientClaims.publicToken,
+          "X-PUBLIC-TOKEN": this.claims.publicToken,
         },
       });
     } catch (err) {
       // Logout is a best effort, do nothing if there is an error remotely
     }
 
-    // Delete JWT from local storage
-    this.clearClientClaims();
+    // Remove claims. Logout has succeeded.
+    this.clearClaims();
+    this.claims = null;
   }
 
   getConnectLocation(requestUri?: string): string {
@@ -209,26 +223,13 @@ export class Transposit {
   }
 
   getUserEmail(): string | null {
-    const clientClaims = this.retrieveClientClaims();
-    if (!clientClaims) {
-      return null;
-    }
-
-    return clientClaims.email;
+    this.assertLoggedIn();
+    return this.claims!.email;
   }
 
   getUserName(): string | null {
-    const clientClaims = this.retrieveClientClaims();
-    if (!clientClaims) {
-      return null;
-    }
-
-    return clientClaims.name;
-  }
-
-  isLoggedIn(): boolean {
-    const clientClaims = this.retrieveClientClaims();
-    return clientClaims !== null && this.areClientClaimsValid(clientClaims);
+    this.assertLoggedIn();
+    return this.claims!.name;
   }
 
   async runOperation(
@@ -239,9 +240,8 @@ export class Transposit {
       "content-type": "application/json",
     } as any;
 
-    const clientClaims = this.retrieveClientClaims();
-    if (clientClaims) {
-      headerInfo["X-PUBLIC-TOKEN"] = clientClaims.publicToken;
+    if (this.claims) {
+      headerInfo["X-PUBLIC-TOKEN"] = this.claims.publicToken;
     }
 
     // Note from MDN: The Promise returned from fetch() won’t reject on HTTP error status even

--- a/src/__tests__/Transposit.test.ts
+++ b/src/__tests__/Transposit.test.ts
@@ -76,7 +76,7 @@ describe("Transposit", () => {
     it("redirects on login", () => {
       const clientJwt: string = createUnsignedJwt(jplaceArbysClaims);
 
-      window.location.href = `https://arbys.com/?clientJwt=${clientJwt}&needsKeys=false`;
+      window.location.search = `?clientJwt=${clientJwt}&needsKeys=false`;
 
       const transposit: Transposit = makeArbysTransposit();
       transposit.handleLogin();
@@ -98,7 +98,7 @@ describe("Transposit", () => {
     it("redirects when needs keys", () => {
       const clientJwt: string = createUnsignedJwt(jplaceArbysClaims);
 
-      window.location.href = `https://arbys.com/?clientJwt=${clientJwt}&needsKeys=true`;
+      window.location.search = `?clientJwt=${clientJwt}&needsKeys=true`;
 
       const transposit: Transposit = makeArbysTransposit();
       transposit.handleLogin();
@@ -120,6 +120,7 @@ describe("Transposit", () => {
       const clientJwt: string = createUnsignedJwt(jplaceArbysClaims);
 
       window.location.href = `https://arbys.com/?clientJwt=${clientJwt}&needsKeys=true`;
+      window.location.search = `?clientJwt=${clientJwt}&needsKeys=true`;
 
       const transposit: Transposit = makeArbysTransposit();
       transposit.handleLogin(mockCallback);
@@ -141,7 +142,7 @@ describe("Transposit", () => {
     it("throws if callback is not a function", (done: DoneCallback) => {
       const clientJwt: string = createUnsignedJwt(jplaceArbysClaims);
 
-      window.location.href = `https://arbys.com/?clientJwt=${clientJwt}&needsKeys=true`;
+      window.location.search = `?clientJwt=${clientJwt}&needsKeys=true`;
 
       const transposit: Transposit = makeArbysTransposit();
       try {
@@ -154,7 +155,7 @@ describe("Transposit", () => {
     });
 
     it("throws without jwt", (done: DoneCallback) => {
-      window.location.href = `https://arbys.com/`;
+      window.location.search = "";
 
       const transposit: Transposit = makeArbysTransposit();
       try {
@@ -171,7 +172,7 @@ describe("Transposit", () => {
     it("throws without needsKeys", (done: DoneCallback) => {
       const clientJwt: string = createUnsignedJwt(jplaceArbysClaims);
 
-      window.location.href = `https://arbys.com/?clientJwt=${clientJwt}`;
+      window.location.search = `?clientJwt=${clientJwt}`;
 
       const transposit: Transposit = makeArbysTransposit();
       try {
@@ -186,7 +187,7 @@ describe("Transposit", () => {
     });
 
     function testInvalidJwt(done: DoneCallback, invalidJwt: string) {
-      window.location.href = `https://arbys.com/?clientJwt=${invalidJwt}&needsKeys=false`;
+      window.location.search = `?clientJwt=${invalidJwt}&needsKeys=false`;
 
       const transposit: Transposit = makeArbysTransposit();
       try {
@@ -226,7 +227,7 @@ describe("Transposit", () => {
       MockDate.set((jplaceArbysClaims.exp - 60 * 60 * 24 * 3) * 1000);
 
       const clientJwt: string = createUnsignedJwt(jplaceArbysClaims);
-      window.location.href = `https://arbys.com/?clientJwt=${clientJwt}&needsKeys=false`;
+      window.location.search = `?clientJwt=${clientJwt}&needsKeys=false`;
       const transposit: Transposit = makeArbysTransposit();
       transposit.handleLogin();
 
@@ -234,20 +235,23 @@ describe("Transposit", () => {
     });
 
     it("knows when you're logged out", () => {
-      window.location.href = `https://arbys.com/`;
+      window.location.search = "";
       const transposit: Transposit = makeArbysTransposit();
 
       expect(transposit.isLoggedIn()).toBe(false);
     });
 
     it("knows when your session expired", () => {
+      const clientJwt: string = createUnsignedJwt(jplaceArbysClaims);
+
+      window.location.search = `?clientJwt=${clientJwt}&needsKeys=false`;
+
+      let transposit: Transposit = makeArbysTransposit();
+      transposit.handleLogin();
+
       // 3 days after expiration
       MockDate.set((jplaceArbysClaims.exp + 60 * 60 * 24 * 3) * 1000);
-
-      const clientJwt: string = createUnsignedJwt(jplaceArbysClaims);
-      window.location.href = `https://arbys.com/?clientJwt=${clientJwt}&needsKeys=false`;
-      const transposit: Transposit = makeArbysTransposit();
-      transposit.handleLogin();
+      transposit = makeArbysTransposit();
 
       expect(transposit.isLoggedIn()).toBe(false);
     });
@@ -259,7 +263,7 @@ describe("Transposit", () => {
     beforeEach(() => {
       const clientJwt: string = createUnsignedJwt(jplaceArbysClaims);
 
-      window.location.href = `https://arbys.com/?clientJwt=${clientJwt}&needsKeys=false`;
+      window.location.search = `?clientJwt=${clientJwt}&needsKeys=false`;
 
       transposit = makeArbysTransposit();
       transposit.handleLogin();


### PR DESCRIPTION
I'm preparing for some significant changes to the SDK. This clean up will make those easier.

- I've stopped using our `getParameterByName` in favor of `URLSearchParams`. I think they are functionally the same.
- The SDK constructor now attempts to load claims from localStorage and keeps them in memory. If no valid claims are found, it continues without claims. Methods that used to load and parse claims from localStorage now reference the in-memory claims.
- `handleLogin` is the only method that can overwrite already loaded claims. It also persists new claims.
- `logOut` is the only method that can nullify already loaded claims. It also removes claims from localStorage.
- `getUserEmail()` and `getUserName()` now will throw if they are called and there a no in-memory claims. They used to return null.

Things I've considered:
- Should the constructor remove expired claims from localStorage if it finds them? I decided no because it might make debugging unexpected state more difficult.
- Is it a breaking change that `getUserEmail()` and `getUserName()` now throw? I decided no, since I can't imagine anyone was depending on null in the first place.

I will fix up the tests a little more and manually test more before pushing this.