### PR TITLE
Deprecate api.transposit.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ npm install transposit
 ```
 
 ```html
-<script src="https://unpkg.com/transposit@0.7.3/dist/bundle.prod.js"></script>
+<script src="https://unpkg.com/transposit@1.0.0/dist/bundle.prod.js"></script>
 ```
 
 Instantiate the SDK with the hosted app origin that uniquely identifies your application:
@@ -122,7 +122,7 @@ Render a sign-out button. Use the SDK to sign out when the buttons is clicked.
 </script>
 ```
 
-## Settings
+## Managed authentication
 
 Allow users to grant access to their third-party data. Use the SDK to link users to the Transposit settings page.
 

--- a/README.md
+++ b/README.md
@@ -22,17 +22,17 @@ $ npm install transposit
 <script src="https://unpkg.com/transposit@0.7.3/dist/bundle.prod.js"></script>
 ```
 
-Instantiate the SDK with the `maintainer`/`name` pair that uniquely identifies your application:
+Instantiate the SDK with the hosted app origin that uniquely identifies your application:
 
 ```javascript
 import { Transposit } from "transposit";
 
-const transposit = new Transposit("jplace", "hello_world");
+const transposit = new Transposit("https://hello-world-xyz12.transposit.io");
 ```
 
 ```html
 <script>
-  const transposit = new Transposit.Transposit("jplace", "hello_world");
+  const transposit = new Transposit.Transposit("https://hello-world-xyz12.transposit.io");
 </script>
 ```
 
@@ -117,22 +117,20 @@ Render a sign-out button. Use the SDK to sign out when the buttons is clicked.
 <button type="button" onclick="signout()">Sign out</button>
 <script>
   function signout() {
-    transposit.logOut().then(() => {
-        window.location.href = "/signin";
-    });
+    transposit.logOut(`${window.location.origin}/signin`);
   }
 </script>
 ```
 
-## Managed authentication
+## Settings
 
-Allow users to grant access to their third-party data. Use the SDK to link users to a Transposit page where they can securely provide credentials.
+Allow users to grant access to their third-party data. Use the SDK to link users to the Transposit settings page.
 
 ```html
-<button type="button" onclick="connect()">Connect</button>
+<button type="button" onclick="settings()">Settings</button>
 <script>
-  function connect() {
-    window.location.href = transposit.getConnectLocation();
+  function settings() {
+    window.location.href = transposit.settingsUri();
   }
 </script>
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -20,7 +20,7 @@ yarn add transposit
 Add via a script tag:
 
 ```markup
-<script src="https://unpkg.com/transposit@0.7.2/dist/bundle.prod.js"></script>
+<script src="https://unpkg.com/transposit@1.0.0/dist/bundle.prod.js"></script>
 ```
 
 ## Usage
@@ -36,7 +36,7 @@ esmodules:
 ```javascript
 import { Transposit } from "transposit";
 
-const transposit = new Transposit(serviceMaintainer, serviceName);
+const transposit = new Transposit("https://hello-world-xyz12.transposit.io");
 ```
 
 commonjs modules:
@@ -44,13 +44,13 @@ commonjs modules:
 ```javascript
 const transposit = require("transposit");
 
-const transposit = new Transposit(serviceMaintainer, serviceName);
+const transposit = new Transposit("https://hello-world-xyz12.transposit.io");
 ```
 
 Or, if you've made the library globally available via a script tag:
 
 ```javascript
-var transposit = new Transposit.Transposit(serviceMaintainer, serviceName);
+var transposit = new Transposit.Transposit("https://hello-world-xyz12.transposit.io");
 ```
 
 ### Login
@@ -80,7 +80,7 @@ Under the hood, this goes through a number of steps to ensure your session is se
 If your application requires user credentials for data connections, send users to the Transposit-hosted data connections page. You can get the URL for this page from the SDK:
 
 ```javascript
-transposit.getConnectionLocation();
+transposit.settingsUri();
 ```
 
 ### Running deployed operation

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -75,9 +75,9 @@ transposit.handleLogin();
 
 Under the hood, this goes through a number of steps to ensure your session is set up correctly in the browser. You are now ready to authorize and run operations!
 
-### Authorizations
+### Settings
 
-If your application requires user credentials for data connections, send users to the Transposit-hosted data connections page. You can get the URL for this page from the SDK:
+If your application requires user credentials for data connections, send users to the Transposit-hosted settings page. You can get the URL for this page from the SDK:
 
 ```javascript
 transposit.settingsUri();

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -36,11 +36,15 @@ try {
 
 ## Log out
 
-`transposit.logOut()`
+`transposit.logOut(redirectUri)`
 
-Invalidates stored claims and clears them from localStorage.
+Invalidates stored claims and clears them from localStorage. Redirects to Tranposit's logout page.
 
-**Returns**: Promise&lt;void&gt;
+| Argument    | Type   |                                                       |
+| :---------- | :----- | :---------------------------------------------------- |
+| redirectUri | String | where to end up after successful logout               |
+
+**Returns**: void
 
 ## Run operation
 
@@ -65,21 +69,21 @@ transposit.runOperation("source.users", { id: params.userId });
 // => { status: "ERROR", result: { exceptionLog: { message: "Failed to find user 123" } } }
 ```
 
-## Get connect location
+## Get settings uri
 
-`transposit.getConnectLocation([redirectUri=window.location.href])`
+`transposit.settingsUri([redirectUri=window.location.href])`
 
 | Argument                           | Type   |                                                       |
 | :--------------------------------- | :----- | :---------------------------------------------------- |
 | [redirectUri=window.location.href] | String | an optional param to specify an alternate redirectUri |
 
-**Returns** (String): A url to redirect to for user authorization.
+**Returns** (String): A url to redirect to for user settings.
 
 **Example**
 
 ```javascript
-transposit.getConnectLocation("localhost");
-// => "https://api.transposit.com/app/v1/gardener/hose/connect?redirectUri=localhost"
+transposit.settingsUri("https://localhost");
+// => "https://hello-world-xyz12.transposit.io?redirectUri=https%3A%2F%2Flocalhost"
 ```
 
 ## Get URI to start Google login
@@ -95,8 +99,8 @@ transposit.getConnectLocation("localhost");
 **Example**
 
 ```javascript
-transposit.getConnectLocation("localhost");
-// => "https://api.transposit.com/app/v1/gardener/hose/login/accounts?redirectUri=localhost"
+transposit.startLoginUri("https://localhost");
+// => "https://hello-world-xyz12.transposit.io/login/accounts?redirectUri=https%3A%2F%2Flocalhost"
 ```
 
 ## Get user name

--- a/src/Transposit.ts
+++ b/src/Transposit.ts
@@ -33,9 +33,7 @@ export interface OperationParameters {
 
 // https://my-app.transposit.io?clientJwt=...needKeys=... -> https://my-app.transposit.io
 function hereWithoutSearch(): string {
-  return `${window.location.protocol}//${window.location.host}${
-    window.location.pathname
-  }`;
+  return `${window.location.origin}${window.location.pathname}`;
 }
 
 export const LOCAL_STORAGE_KEY = "TRANSPOSIT_SESSION";
@@ -170,18 +168,19 @@ export class Transposit {
     }
   }
 
-  // todo eventually allow a redirect uri
-  logOut(): void {
+  logOut(redirectUri: string): void {
     this.clearClaims();
     this.claims = null;
 
-    window.location.href = this.uri("/logout");
+    window.location.href = this.uri(
+      `/logout?redirectUri=${encodeURIComponent(redirectUri)}`,
+    );
   }
 
-  settingsUri(requestUri?: string): string {
+  settingsUri(redirectUri?: string): string {
     return this.uri(
       `/settings?redirectUri=${encodeURIComponent(
-        requestUri || window.location.href,
+        redirectUri || window.location.href,
       )}`,
     );
   }
@@ -194,13 +193,9 @@ export class Transposit {
     );
   }
 
-  loginUri(): string {
-    return this.uri("/login");
-  }
-
   // Deprecated in favor of settingsUri
-  getConnectLocation(requestUri?: string): string {
-    return this.settingsUri(requestUri);
+  getConnectLocation(redirectUri?: string): string {
+    return this.settingsUri(redirectUri);
   }
 
   // Deprecated in favor of startLoginUri
@@ -208,7 +203,7 @@ export class Transposit {
     return this.startLoginUri(redirectUri);
   }
 
-  // Deprecated in favor of loginUri
+  // Deprecated
   getLoginLocation(): string {
     return this.uri("/login");
   }

--- a/src/Transposit.ts
+++ b/src/Transposit.ts
@@ -42,12 +42,12 @@ export class Transposit {
   private claims: ClientClaims | null = null;
 
   // todo backwards compatibility with old key?
-  constructor(private baseUri: string = "") {
+  constructor(private hostedAppOrigin: string = "") {
     this.claims = this.loadClaims();
   }
 
-  private uri(relativePath: string = ""): string {
-    return `${this.baseUri}${relativePath}`;
+  private uri(path: string = ""): string {
+    return `${this.hostedAppOrigin}${path}`;
   }
 
   private loadClaims(): ClientClaims | null {

--- a/src/Transposit.ts
+++ b/src/Transposit.ts
@@ -41,7 +41,6 @@ export const LOCAL_STORAGE_KEY = "TRANSPOSIT_SESSION";
 export class Transposit {
   private claims: ClientClaims | null = null;
 
-  // todo backwards compatibility with old key?
   constructor(private hostedAppOrigin: string = "") {
     this.claims = this.loadClaims();
   }

--- a/src/Transposit.ts
+++ b/src/Transposit.ts
@@ -49,16 +49,10 @@ function getParameterByName(name: string): string | null {
 export const TRANSPOSIT_CONSUME_KEY_PREFIX = "TRANSPOSIT_CONSUME_KEY";
 
 export class Transposit {
-  constructor(
-    private serviceMaintainer: string,
-    private serviceName: string,
-    private tpsHostedAppApiUrl: string = "https://api.transposit.com",
-  ) {}
+  constructor(private baseUrl: string) {}
 
   private getConsumeKey(): string {
-    return `${TRANSPOSIT_CONSUME_KEY_PREFIX}/${this.serviceMaintainer}/${
-      this.serviceName
-    }`;
+    return `${TRANSPOSIT_CONSUME_KEY_PREFIX}/${this.baseUrl}`;
   }
 
   private retrieveClientClaims(): ClientClaims | null {
@@ -85,9 +79,7 @@ export class Transposit {
   }
 
   private apiUrl(relativePath: string = ""): string {
-    return `${this.tpsHostedAppApiUrl}/app/${this.serviceMaintainer}/${
-      this.serviceName
-    }${relativePath}`;
+    return `${this.baseUrl}${relativePath}`;
   }
 
   handleLogin(callback?: (info: { needsKeys: boolean }) => void): void {

--- a/src/__tests__/Transposit.test.ts
+++ b/src/__tests__/Transposit.test.ts
@@ -46,8 +46,7 @@ describe("Transposit", () => {
     jest.clearAllMocks();
     localStorage.clear();
     MockDate.set(NOW);
-    window.location.search = "";
-    window.location.href = arbysUri("/");
+    setHref(ARBYS_ORIGIN, "/", "");
   });
 
   const jplaceArbysClaims: ClientClaims = Object.freeze({

--- a/src/__tests__/Transposit.test.ts
+++ b/src/__tests__/Transposit.test.ts
@@ -31,8 +31,9 @@ describe("Transposit", () => {
     MockDate.reset();
   });
 
+  const jplaceArbysBaseUri: string = "https://arbys-beef-xyz12.transposit.io";
   const jplaceArbysClaims: any = Object.freeze({
-    iss: "https://api.transposit.com",
+    iss: jplaceArbysBaseUri,
     sub: "jplace@transposit.com",
     exp: 1522255319,
     iat: 1521650519,
@@ -41,33 +42,18 @@ describe("Transposit", () => {
   });
 
   function makeArbysTransposit(): Transposit {
-    return new Transposit("jplace", "arbys_beef");
+    return new Transposit(jplaceArbysBaseUri);
   }
 
   describe("getGoogleLoginLocation", () => {
     it("returns the correct location", () => {
-      const transposit: Transposit = new Transposit("jplace", "arbys_beef");
+      const transposit: Transposit = makeArbysTransposit();
 
       expect(transposit.getGoogleLoginLocation("https://altoids.com")).toEqual(
-        "https://api.transposit.com/app/jplace/arbys_beef/login/accounts?redirectUri=https%3A%2F%2Faltoids.com",
+        "https://arbys-beef-xyz12.transposit.io/login/accounts?redirectUri=https%3A%2F%2Faltoids.com",
       );
       expect(transposit.startLoginUri("https://altoids.com")).toEqual(
-        "https://api.transposit.com/app/jplace/arbys_beef/login/accounts?redirectUri=https%3A%2F%2Faltoids.com",
-      );
-    });
-
-    it("returns the correct location (non-default transposit location)", () => {
-      const transposit: Transposit = new Transposit(
-        "jplace",
-        "arbys_beef",
-        "https://monkey.transposit.com",
-      );
-
-      expect(transposit.getGoogleLoginLocation("https://altoids.com")).toEqual(
-        "https://monkey.transposit.com/app/jplace/arbys_beef/login/accounts?redirectUri=https%3A%2F%2Faltoids.com",
-      );
-      expect(transposit.startLoginUri("https://altoids.com")).toEqual(
-        "https://monkey.transposit.com/app/jplace/arbys_beef/login/accounts?redirectUri=https%3A%2F%2Faltoids.com",
+        "https://arbys-beef-xyz12.transposit.io/login/accounts?redirectUri=https%3A%2F%2Faltoids.com",
       );
     });
   });
@@ -84,7 +70,7 @@ describe("Transposit", () => {
       expect(
         JSON.parse(
           localStorage.getItem(
-            `${TRANSPOSIT_CONSUME_KEY_PREFIX}/jplace/arbys_beef`,
+            `${TRANSPOSIT_CONSUME_KEY_PREFIX}/https://arbys-beef-xyz12.transposit.io`,
           )!,
         ),
       ).toEqual(jplaceArbysClaims);
@@ -106,12 +92,12 @@ describe("Transposit", () => {
       expect(
         JSON.parse(
           localStorage.getItem(
-            `${TRANSPOSIT_CONSUME_KEY_PREFIX}/jplace/arbys_beef`,
+            `${TRANSPOSIT_CONSUME_KEY_PREFIX}/https://arbys-beef-xyz12.transposit.io`,
           )!,
         ),
       ).toEqual(jplaceArbysClaims);
       expect(window.location.href).toEqual(
-        "https://api.transposit.com/app/jplace/arbys_beef/connect?redirectUri=http%3A%2F%2Flocalhost%2F",
+        "https://arbys-beef-xyz12.transposit.io/connect?redirectUri=http%3A%2F%2Flocalhost%2F",
       );
     });
 
@@ -276,7 +262,7 @@ describe("Transposit", () => {
 
       expect(
         localStorage.getItem(
-          `${TRANSPOSIT_CONSUME_KEY_PREFIX}/jplace/arbys_beef`,
+          `${TRANSPOSIT_CONSUME_KEY_PREFIX}/https://arbys-beef-xyz12.transposit.io`,
         ),
       ).toBeNull();
     });

--- a/src/__tests__/Transposit.test.ts
+++ b/src/__tests__/Transposit.test.ts
@@ -74,13 +74,9 @@ describe("Transposit", () => {
       const transposit: Transposit = makeArbysTransposit();
       transposit.handleLogin();
 
-      expect(
-        JSON.parse(
-          localStorage.getItem(
-            `${LOCAL_STORAGE_KEY}/https://arbys-beef-xyz12.transposit.io`,
-          )!,
-        ),
-      ).toEqual(jplaceArbysClaims);
+      expect(JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY)!)).toEqual(
+        jplaceArbysClaims,
+      );
       expect(window.history.replaceState).toHaveBeenCalledWith(
         {},
         window.document.title,
@@ -96,13 +92,9 @@ describe("Transposit", () => {
       const transposit: Transposit = makeArbysTransposit();
       transposit.handleLogin();
 
-      expect(
-        JSON.parse(
-          localStorage.getItem(
-            `${LOCAL_STORAGE_KEY}/https://arbys-beef-xyz12.transposit.io`,
-          )!,
-        ),
-      ).toEqual(jplaceArbysClaims);
+      expect(JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY)!)).toEqual(
+        jplaceArbysClaims,
+      );
       expect(window.location.href).toEqual(
         "https://arbys-beef-xyz12.transposit.io/connect?redirectUri=http%3A%2F%2Flocalhost%2F",
       );
@@ -117,11 +109,9 @@ describe("Transposit", () => {
       const transposit: Transposit = makeArbysTransposit();
       transposit.handleLogin(mockCallback);
 
-      expect(
-        JSON.parse(
-          localStorage.getItem(`${LOCAL_STORAGE_KEY}/jplace/arbys_beef`)!,
-        ),
-      ).toEqual(jplaceArbysClaims);
+      expect(JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY)!)).toEqual(
+        jplaceArbysClaims,
+      );
       expect(mockCallback).toHaveBeenCalledWith({ needsKeys: true });
       expect(window.history.replaceState).not.toHaveBeenCalled();
     });
@@ -263,21 +253,14 @@ describe("Transposit", () => {
       transposit.handleLogin();
     });
 
-    it("handles successful logout", async () => {
-      expect.assertions(2);
+    it("handles successful logout", () => {
+      transposit.logOut("https://arbys-beef-xyz12.transposit.io/login");
 
-      (window.fetch as jest.Mock<{}>).mockImplementation(() =>
-        Promise.resolve(),
-      );
-
-      await transposit.logOut();
-
-      expect(
-        localStorage.getItem(
-          `${LOCAL_STORAGE_KEY}/https://arbys-beef-xyz12.transposit.io`,
-        ),
-      ).toBeNull();
+      expect(localStorage.getItem(LOCAL_STORAGE_KEY)).toBeNull();
       expect(transposit.isLoggedIn()).toBe(false);
+      expect(window.location.href).toEqual(
+        "https://arbys-beef-xyz12.transposit.io/logout?redirectUri=http%3A%2F%2Flocalhost%2F",
+      );
     });
   });
 });

--- a/src/__tests__/Transposit.test.ts
+++ b/src/__tests__/Transposit.test.ts
@@ -48,6 +48,7 @@ describe("Transposit", () => {
     name: "Jordan 'The Beef' Place",
   });
 
+  // todo this should probably have no argument passed in
   function makeArbysTransposit(): Transposit {
     return new Transposit(jplaceArbysBaseUri);
   }
@@ -68,7 +69,6 @@ describe("Transposit", () => {
   describe("handleLogin", () => {
     it("calls replaceState", () => {
       const clientJwt: string = createUnsignedJwt(jplaceArbysClaims);
-
       window.location.search = `?clientJwt=${clientJwt}&needsKeys=false`;
 
       const transposit: Transposit = makeArbysTransposit();
@@ -86,7 +86,6 @@ describe("Transposit", () => {
 
     it("redirects when needs keys", () => {
       const clientJwt: string = createUnsignedJwt(jplaceArbysClaims);
-
       window.location.search = `?clientJwt=${clientJwt}&needsKeys=true`;
 
       const transposit: Transposit = makeArbysTransposit();
@@ -103,7 +102,6 @@ describe("Transposit", () => {
     it("calls callback", () => {
       const mockCallback = jest.fn();
       const clientJwt: string = createUnsignedJwt(jplaceArbysClaims);
-
       window.location.search = `?clientJwt=${clientJwt}&needsKeys=true`;
 
       const transposit: Transposit = makeArbysTransposit();
@@ -118,7 +116,6 @@ describe("Transposit", () => {
 
     it("throws if callback is not a function", (done: DoneCallback) => {
       const clientJwt: string = createUnsignedJwt(jplaceArbysClaims);
-
       window.location.search = `?clientJwt=${clientJwt}&needsKeys=true`;
 
       const transposit: Transposit = makeArbysTransposit();
@@ -148,7 +145,6 @@ describe("Transposit", () => {
 
     it("throws without needsKeys", (done: DoneCallback) => {
       const clientJwt: string = createUnsignedJwt(jplaceArbysClaims);
-
       window.location.search = `?clientJwt=${clientJwt}`;
 
       const transposit: Transposit = makeArbysTransposit();
@@ -207,11 +203,9 @@ describe("Transposit", () => {
 
   describe("isLoggedIn", () => {
     it("knows when you're logged in", () => {
-      // 3 days before expiration
-      MockDate.set((jplaceArbysClaims.exp - 60 * 60 * 24 * 3) * 1000);
-
       const clientJwt: string = createUnsignedJwt(jplaceArbysClaims);
       window.location.search = `?clientJwt=${clientJwt}&needsKeys=false`;
+
       const transposit: Transposit = makeArbysTransposit();
       transposit.handleLogin();
 
@@ -219,7 +213,6 @@ describe("Transposit", () => {
     });
 
     it("knows when you're logged out", () => {
-      window.location.search = "";
       const transposit: Transposit = makeArbysTransposit();
 
       expect(transposit.isLoggedIn()).toBe(false);
@@ -227,7 +220,6 @@ describe("Transposit", () => {
 
     it("knows when your session expired", () => {
       const clientJwt: string = createUnsignedJwt(jplaceArbysClaims);
-
       window.location.search = `?clientJwt=${clientJwt}&needsKeys=false`;
 
       let transposit: Transposit = makeArbysTransposit();
@@ -246,7 +238,6 @@ describe("Transposit", () => {
 
     beforeEach(() => {
       const clientJwt: string = createUnsignedJwt(jplaceArbysClaims);
-
       window.location.search = `?clientJwt=${clientJwt}&needsKeys=false`;
 
       transposit = makeArbysTransposit();

--- a/src/__tests__/Transposit.test.ts
+++ b/src/__tests__/Transposit.test.ts
@@ -15,11 +15,7 @@
  */
 
 import * as MockDate from "mockdate";
-import {
-  ClientClaims,
-  Transposit,
-  TRANSPOSIT_CONSUME_KEY_PREFIX,
-} from "../Transposit";
+import { ClientClaims, LOCAL_STORAGE_KEY, Transposit } from "../Transposit";
 
 import DoneCallback = jest.DoneCallback;
 
@@ -81,7 +77,7 @@ describe("Transposit", () => {
       expect(
         JSON.parse(
           localStorage.getItem(
-            `${TRANSPOSIT_CONSUME_KEY_PREFIX}/https://arbys-beef-xyz12.transposit.io`,
+            `${LOCAL_STORAGE_KEY}/https://arbys-beef-xyz12.transposit.io`,
           )!,
         ),
       ).toEqual(jplaceArbysClaims);
@@ -103,7 +99,7 @@ describe("Transposit", () => {
       expect(
         JSON.parse(
           localStorage.getItem(
-            `${TRANSPOSIT_CONSUME_KEY_PREFIX}/https://arbys-beef-xyz12.transposit.io`,
+            `${LOCAL_STORAGE_KEY}/https://arbys-beef-xyz12.transposit.io`,
           )!,
         ),
       ).toEqual(jplaceArbysClaims);
@@ -123,9 +119,7 @@ describe("Transposit", () => {
 
       expect(
         JSON.parse(
-          localStorage.getItem(
-            `${TRANSPOSIT_CONSUME_KEY_PREFIX}/jplace/arbys_beef`,
-          )!,
+          localStorage.getItem(`${LOCAL_STORAGE_KEY}/jplace/arbys_beef`)!,
         ),
       ).toEqual(jplaceArbysClaims);
       expect(mockCallback).toHaveBeenCalledWith({ needsKeys: true });
@@ -280,7 +274,7 @@ describe("Transposit", () => {
 
       expect(
         localStorage.getItem(
-          `${TRANSPOSIT_CONSUME_KEY_PREFIX}/https://arbys-beef-xyz12.transposit.io`,
+          `${LOCAL_STORAGE_KEY}/https://arbys-beef-xyz12.transposit.io`,
         ),
       ).toBeNull();
       expect(transposit.isLoggedIn()).toBe(false);


### PR DESCRIPTION
Transposit gives each deployed application its own subdomain on transposit.io. The SDK now exclusively communicates with this origin for login, settings and execution.

This change includes a couple breaking changes to the SDK:
- The SDK's constructor no longer needs the maintainer/serviceName and host. It now only needs the hosted app origin.
- To log out, the SDK no longer relies on CORS. It now redirects to a logout page implemented by Transposit.
- `getLoginLocation` has been deprecated. The SDK no longer assumes you are using a Transposit-provided login page.