### PR TITLE
Load user information via API

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ Create a page that handles redirection at the end of sign-in. Use the SDK to com
 </script>
 ```
 
-### Signed-in routes
+### Signed in routes
 
-For all routes that require sign-in, check if the user is signed-in. Redirect to your sign-in page if they are not.
+For all routes that require sign-in, check if the user is signed in. Redirect to your sign-in page if they are not.
 
 ```html
 <script>

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -123,9 +123,9 @@ transposit.getUserName();
 
 `transposit.getUserEmail()`
 
-Returns the email address of the signed-in user.
+Returns the email address of the signed in user.
 
-**Returns** (String): The email address of the signed-in user
+**Returns** (String): The email address of the signed in user
 
 **Example**
 

--- a/src/Transposit.ts
+++ b/src/Transposit.ts
@@ -22,6 +22,7 @@ import {
   persistAccessToken,
   TokenResponse,
 } from "./signin/token";
+import { User } from "./signin/user";
 import { chompSlash, formUrlEncode, hereWithoutSearch } from "./utils";
 
 export class Transposit {
@@ -41,6 +42,14 @@ export class Transposit {
 
   private load(): void {
     this.accessToken = loadAccessToken();
+  }
+
+  private assertIsSignedIn(): void {
+    if (!this.accessToken) {
+      throw new Error(
+        "This method can only be called if the user is signed in",
+      );
+    }
   }
 
   isSignedIn(): boolean {
@@ -127,6 +136,23 @@ export class Transposit {
     );
   }
 
+  async loadUser(): Promise<User> {
+    this.assertIsSignedIn();
+
+    const response = await fetch(this.uri("/api/v1/user"), {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this.accessToken}`,
+      },
+    });
+    if (!response.ok) {
+      throw response;
+    }
+
+    return (await response.json()) as User;
+  }
+
   async run(
     operationId: string,
     parameters: OperationParameters = {},
@@ -145,12 +171,11 @@ export class Transposit {
         parameters,
       }),
     });
-
-    if (response.status >= 200 && response.status < 300) {
-      return (await response.json()) as EndRequestLog;
-    } else {
+    if (!response.ok) {
       throw response;
     }
+
+    return (await response.json()) as EndRequestLog;
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,3 +16,4 @@
 
 export * from "./EndRequestLog";
 export * from "./Transposit";
+export { User } from "./signin/user";

--- a/src/signin/token.ts
+++ b/src/signin/token.ts
@@ -17,11 +17,6 @@
 export interface TokenResponse {
   access_token: string;
   needs_keys: boolean;
-  user: User;
-}
-export interface User {
-  name: string;
-  email: string;
 }
 
 export interface Claims {

--- a/src/signin/user.ts
+++ b/src/signin/user.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 Transposit Corporation. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface User {
+  name: string;
+  email: string;
+}


### PR DESCRIPTION
I've added a method for loading the user via `fetch`. The SDK does not cache the user in memory for you. It assumes you'll put it in React `state` or somewhere else once loaded.

Bonus:
- I replaced "signed-in" with grammatically correct "signed in".

Backend review [here](https://github.com/transposit/transposit/pull/2107). Sample of using the SDK to fetch this information [here](https://github.com/transposit/check_my_cal/pull/1).