### PR TITLE
TR-4932 Add support for stash operations

### DIFF
--- a/src/KeyValueStore.ts
+++ b/src/KeyValueStore.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018, 2019 Transposit Corporation. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Represents a key/value store, such as stash, env, etc.
+ * @export
+ * @interface KeyValueStore
+ */
+export interface KeyValueStore<T> {
+  listKeys(): Promise<string[]>;
+  get(key: string): Promise<T | null>;
+}
+
+export interface MutableKeyValueStore<T> extends KeyValueStore<T> {
+  put(key: string, value: T): Promise<void>;
+  remove(key: string): Promise<void>;
+}
+
+/**
+ * Represents a key and a value stored in a key/value store.
+ * @export
+ * @interface KeyValuePair
+ */
+export interface KeyValuePair<T> {
+  /**
+   *
+   * @type {string}
+   * @memberof KeyValuePair
+   */
+  key: string;
+  /**
+   *
+   * @type {T}
+   * @memberof KeyValuePair
+   */
+  value: T;
+}

--- a/src/Stash.ts
+++ b/src/Stash.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018, 2019 Transposit Corporation. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Transposit } from ".";
+import { KeyValuePair, MutableKeyValueStore } from "./KeyValueStore";
+
+export class Stash implements MutableKeyValueStore<any> {
+
+  private transposit: Transposit;
+  constructor(transposit: Transposit) {
+    this.transposit = transposit;
+  }
+
+  async listKeys(): Promise<string[]> {
+    const pairs = await this.transposit.makeCallJson<KeyValuePair<any>[]>("GET", "/api/v1/stash", {});
+    return pairs.map(pair => pair.key);
+  }
+
+  async get(key: string): Promise<any> {
+    const pairs = await this.transposit.makeCallJson<KeyValuePair<any>[]>("GET", "/api/v1/stash", {keyName: key});
+    if (pairs.length == 0) {
+      return null;
+    } else {
+      return pairs[0].value;
+    }
+  }
+
+  async put(key: string, value: any): Promise<void> {
+    return this.transposit.makeCall("POST", "/api/v1/stash", {}, {key: key, value: value}).then(_ => {});
+  }
+
+  async remove(key: string): Promise<void> {
+    return this.transposit.makeCall("DELETE", "/api/v1/stash", {keyName: key}).then(_ => {});
+  }
+}
+

--- a/src/Stash.ts
+++ b/src/Stash.ts
@@ -18,19 +18,26 @@ import { Transposit } from ".";
 import { KeyValuePair, MutableKeyValueStore } from "./KeyValueStore";
 
 export class Stash implements MutableKeyValueStore<any> {
-
   private transposit: Transposit;
   constructor(transposit: Transposit) {
     this.transposit = transposit;
   }
 
   async listKeys(): Promise<string[]> {
-    const pairs = await this.transposit.makeCallJson<KeyValuePair<any>[]>("GET", "/api/v1/stash", {});
+    const pairs = await this.transposit.makeCallJson<KeyValuePair<any>[]>(
+      "GET",
+      "/api/v1/stash",
+      {},
+    );
     return pairs.map(pair => pair.key);
   }
 
   async get(key: string): Promise<any> {
-    const pairs = await this.transposit.makeCallJson<KeyValuePair<any>[]>("GET", "/api/v1/stash", {keyName: key});
+    const pairs = await this.transposit.makeCallJson<KeyValuePair<any>[]>(
+      "GET",
+      "/api/v1/stash",
+      { keyName: key },
+    );
     if (pairs.length == 0) {
       return null;
     } else {
@@ -39,11 +46,14 @@ export class Stash implements MutableKeyValueStore<any> {
   }
 
   async put(key: string, value: any): Promise<void> {
-    return this.transposit.makeCall("POST", "/api/v1/stash", {}, {key: key, value: value}).then(_ => {});
+    return this.transposit
+      .makeCall("POST", "/api/v1/stash", {}, { key: key, value: value })
+      .then(_ => {});
   }
 
   async remove(key: string): Promise<void> {
-    return this.transposit.makeCall("DELETE", "/api/v1/stash", {keyName: key}).then(_ => {});
+    return this.transposit
+      .makeCall("DELETE", "/api/v1/stash", { keyName: key })
+      .then(_ => {});
   }
 }
-

--- a/src/Stash.ts
+++ b/src/Stash.ts
@@ -38,7 +38,7 @@ export class Stash implements MutableKeyValueStore<any> {
       "/api/v1/stash",
       { keyName },
     );
-    if (pairs.length == 0) {
+    if (pairs.length === 0) {
       return null;
     } else {
       return pairs[0].value;
@@ -48,12 +48,12 @@ export class Stash implements MutableKeyValueStore<any> {
   async put(key: string, value: any): Promise<void> {
     return this.transposit
       .makeCall("POST", "/api/v1/stash", {}, { key, value })
-      .then(_ => {});
+      .then(_ => undefined);
   }
 
   async remove(keyName: string): Promise<void> {
     return this.transposit
       .makeCall("DELETE", "/api/v1/stash", { keyName })
-      .then(_ => {});
+      .then(_ => undefined);
   }
 }

--- a/src/Stash.ts
+++ b/src/Stash.ts
@@ -32,11 +32,11 @@ export class Stash implements MutableKeyValueStore<any> {
     return pairs.map(pair => pair.key);
   }
 
-  async get(key: string): Promise<any> {
+  async get(keyName: string): Promise<any> {
     const pairs = await this.transposit.makeCallJson<KeyValuePair<any>[]>(
       "GET",
       "/api/v1/stash",
-      { keyName: key },
+      { keyName },
     );
     if (pairs.length == 0) {
       return null;
@@ -47,13 +47,13 @@ export class Stash implements MutableKeyValueStore<any> {
 
   async put(key: string, value: any): Promise<void> {
     return this.transposit
-      .makeCall("POST", "/api/v1/stash", {}, { key: key, value: value })
+      .makeCall("POST", "/api/v1/stash", {}, { key, value })
       .then(_ => {});
   }
 
-  async remove(key: string): Promise<void> {
+  async remove(keyName: string): Promise<void> {
     return this.transposit
-      .makeCall("DELETE", "/api/v1/stash", { keyName: key })
+      .makeCall("DELETE", "/api/v1/stash", { keyName })
       .then(_ => {});
   }
 }

--- a/src/Transposit.ts
+++ b/src/Transposit.ts
@@ -227,7 +227,12 @@ export class Transposit {
     operationId: string,
     params: OperationParameters = {},
   ): Promise<EndRequestLog> {
-    return this.makeCallJson<EndRequestLog>("POST", `/api/v1/execute/${operationId}`, {}, {parameters: params});
+    return this.makeCallJson<EndRequestLog>(
+      "POST",
+      `/api/v1/execute/${operationId}`,
+      {},
+      { parameters: params },
+    );
   }
 
   async makeCallJson<T>(
@@ -237,7 +242,7 @@ export class Transposit {
     params?: any,
   ): Promise<T> {
     const response = await this.makeCall(method, path, queryParams, params);
-    return (await response.json());
+    return await response.json();
   }
 
   async makeCall(
@@ -254,7 +259,9 @@ export class Transposit {
     }
 
     const url = new URL(path, this.hostedAppOrigin);
-    Object.keys(queryParams).forEach(key => url.searchParams.append(key, queryParams[key]));
+    Object.keys(queryParams).forEach(key =>
+      url.searchParams.append(key, queryParams[key]),
+    );
 
     const body = params == null ? null : JSON.stringify(params);
 
@@ -266,7 +273,7 @@ export class Transposit {
     });
 
     if (response.status >= 200 && response.status < 300) {
-      return response; 
+      return response;
     } else {
       throw response;
     }

--- a/src/Transposit.ts
+++ b/src/Transposit.ts
@@ -267,9 +267,9 @@ export class Transposit {
 
     const response = await fetch(url.href, {
       credentials: "include",
-      method: method,
+      method,
       headers,
-      body: body,
+      body,
     });
 
     if (response.status >= 200 && response.status < 300) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,4 +15,6 @@
  */
 
 export * from "./EndRequestLog";
+export { KeyValueStore, MutableKeyValueStore } from "./KeyValueStore";
 export * from "./Transposit";
+export * from "./Stash";


### PR DESCRIPTION
Add a Stash object with operations mirroring stash functionality when
running operations directly.

Separating into a stash object rather than just adding methods like
getStash() hides clutter when looking at documentation or using code
completion tools.

Created KeyValueStore interfaces in preparation for adding env and
user_settings, which have similar features and which people may want to
handle generically.

Includes a refactor of the code used to make HTTP calls to support
typed returns, empty returns, query parameters, etc.