### PR TITLE
TR-5031 Better error model for SDK

### DIFF
--- a/src/__tests__/Transposit.test.ts
+++ b/src/__tests__/Transposit.test.ts
@@ -31,6 +31,7 @@ import {
   setHref,
 } from "../test/test-utils";
 import { SignInSuccess, Transposit } from "../Transposit";
+import { APIError } from "../errors/APIError";
 jest.mock("../signin/pkce-helper");
 
 const BACKEND_ORIGIN: string = "https://arbys-beef-xyz12.transposit.io";
@@ -188,7 +189,7 @@ describe("Transposit", () => {
     setHref(FRONTEND_ORIGIN, "/handle-signin", `?code=some-code-to-trade`);
 
     (window.fetch as jest.Mock).mockReturnValueOnce(
-      Promise.reject(new Error("Network error")),
+      Promise.reject(new TypeError("Network error")),
     );
 
     const transposit: Transposit = new Transposit(BACKEND_ORIGIN);
@@ -196,6 +197,7 @@ describe("Transposit", () => {
     try {
       await transposit.handleSignIn();
     } catch (e) {
+      expect(e).toBeInstanceOf(TypeError);
       expect(e.message).toBe("Network error");
     }
   });
@@ -350,6 +352,7 @@ describe("Transposit", () => {
     try {
       await transposit.run("hello_world");
     } catch (e) {
+      expect(e).toBeInstanceOf(APIError);
       expect(e.statusText).toEqual("Bad Request");
     }
   });

--- a/src/__tests__/Transposit.test.ts
+++ b/src/__tests__/Transposit.test.ts
@@ -32,10 +32,8 @@ import {
   setHref,
 } from "../test/test-utils";
 import { SignInSuccess, Transposit } from "../Transposit";
+import { INTERNAL_ERROR_MESSAGE } from "../utils/tr-fetch";
 jest.mock("../signin/pkce-helper");
-
-// todo delete this?
-// jest.unmock("../utils/tr-fetch.ts");
 
 const BACKEND_ORIGIN: string = "https://arbys-beef-xyz12.transposit.io";
 function backendUri(path: string = ""): string {
@@ -359,9 +357,7 @@ describe("Transposit", () => {
       await transposit.run("hello_world");
     } catch (e) {
       expect(e).toBeInstanceOf(APIError);
-      expect(e.message).toEqual(
-        "API call failed in an unexpected way. Try this operation again.",
-      );
+      expect(e.message).toEqual(INTERNAL_ERROR_MESSAGE);
     }
   });
 });

--- a/src/__tests__/Transposit.test.ts
+++ b/src/__tests__/Transposit.test.ts
@@ -181,9 +181,7 @@ describe("Transposit", () => {
       await transposit.handleSignIn();
     } catch (e) {
       expect(e).toBeInstanceOf(APIError);
-      expect(e.message).toBe(
-        "API call failed in an unexpected way. Try this operation again.",
-      );
+      expect(e.message).toBe(INTERNAL_ERROR_MESSAGE);
     }
   });
 
@@ -342,7 +340,7 @@ describe("Transposit", () => {
     );
   });
 
-  it.only("run an operation and throws errors", async () => {
+  it("run an operation and throws errors", async () => {
     expect.assertions(2);
 
     makeSignedIn(accessToken);

--- a/src/errors/APIError.ts
+++ b/src/errors/APIError.ts
@@ -26,5 +26,8 @@ export class APIError extends SDKError {
     super(message);
     this.name = "APIError";
     this.response = response;
+
+    // https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    Object.setPrototypeOf(this, APIError.prototype);
   }
 }

--- a/src/errors/APIError.ts
+++ b/src/errors/APIError.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Transposit Corporation. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SDKError } from "./SDKError";
+
+/**
+ * An APIError is an SDKError that always includes the raw response object.
+ */
+export class APIError extends SDKError {
+  response: Response;
+
+  constructor(message: string, response: Response) {
+    super(message);
+    this.name = "APIError";
+    this.response = response;
+  }
+}

--- a/src/errors/SDKError.ts
+++ b/src/errors/SDKError.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Transposit Corporation. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * An SDKError is an Error that always have a user-visible message.
+ */
+export class SDKError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SDKError";
+  }
+}

--- a/src/errors/SDKError.ts
+++ b/src/errors/SDKError.ts
@@ -15,11 +15,14 @@
  */
 
 /**
- * An SDKError is an Error that always have a user-visible message.
+ * An SDKError is an Error that always has a user-visible message.
  */
 export class SDKError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "SDKError";
+
+    // https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    Object.setPrototypeOf(this, SDKError.prototype);
   }
 }

--- a/src/signin/pkce-helper.ts
+++ b/src/signin/pkce-helper.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 // This code inspired by: https://developer.okta.com/blog/2019/05/01/is-the-oauth-implicit-flow-dead
+
+import { SDKError } from "../errors/SDKError";
 
 const PKCE_KEY = "TRANPOSIT_PKCE";
 
@@ -51,7 +52,7 @@ export async function pushCodeVerifier(): Promise<string> {
 export function popCodeVerifier(): string {
   const maybeCodeVerifier: string | null = localStorage.getItem(PKCE_KEY);
   if (!maybeCodeVerifier) {
-    throw new Error("PKCE state could not be found.");
+    throw new SDKError("PKCE state could not be found.");
   }
   localStorage.removeItem(PKCE_KEY);
   return maybeCodeVerifier;

--- a/src/utils/__tests__/tr-fetch.test.ts
+++ b/src/utils/__tests__/tr-fetch.test.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2019 Transposit Corporation. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { APIError } from "../../errors/APIError";
+import { INTERNAL_ERROR_MESSAGE, trfetch } from "../tr-fetch";
+
+describe("tr-fetch", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const unusedRequestInfo: RequestInfo = "/api/v1/user";
+
+  it("deserializes good json in 2XX response", async () => {
+    expect.assertions(1);
+
+    const expected: {} = { everything: "is", a: "okay!" };
+
+    (window.fetch as jest.Mock).mockReturnValueOnce(
+      Promise.resolve(
+        new Response(JSON.stringify(expected), {
+          status: 200,
+        }),
+      ),
+    );
+
+    const actual = await trfetch<{}>(unusedRequestInfo);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it("throws on bad json in 2XX response", async () => {
+    expect.assertions(2);
+
+    (window.fetch as jest.Mock).mockReturnValueOnce(
+      Promise.resolve(
+        new Response("totaljunk", {
+          status: 200,
+        }),
+      ),
+    );
+
+    try {
+      await trfetch<{}>(unusedRequestInfo);
+    } catch (e) {
+      expect(e).toBeInstanceOf(APIError);
+      expect(e.message).toBe(INTERNAL_ERROR_MESSAGE);
+    }
+  });
+
+  it("throws on user-visible error in 4XX response", async () => {
+    expect.assertions(2);
+
+    (window.fetch as jest.Mock).mockReturnValueOnce(
+      Promise.resolve(
+        new Response(
+          JSON.stringify({ id: "some.id", message: "dance your face off" }),
+          {
+            status: 400,
+          },
+        ),
+      ),
+    );
+
+    try {
+      await trfetch<{}>(unusedRequestInfo);
+    } catch (e) {
+      expect(e).toBeInstanceOf(APIError);
+      expect(e.message).toBe("dance your face off");
+    }
+  });
+
+  it("throws on quiet error in 4XX response", async () => {
+    expect.assertions(2);
+
+    (window.fetch as jest.Mock).mockReturnValueOnce(
+      Promise.resolve(
+        new Response(null, {
+          status: 400,
+        }),
+      ),
+    );
+
+    try {
+      await trfetch<{}>(unusedRequestInfo);
+    } catch (e) {
+      expect(e).toBeInstanceOf(APIError);
+      expect(e.message).toBe(INTERNAL_ERROR_MESSAGE);
+    }
+  });
+
+  it("throws on internal error in 5XX response", async () => {
+    expect.assertions(2);
+
+    (window.fetch as jest.Mock).mockReturnValueOnce(
+      Promise.resolve(
+        new Response("An unexpected error occurred. Try again.", {
+          status: 500,
+        }),
+      ),
+    );
+
+    try {
+      await trfetch<{}>(unusedRequestInfo);
+    } catch (e) {
+      expect(e).toBeInstanceOf(APIError);
+      expect(e.message).toBe(INTERNAL_ERROR_MESSAGE);
+    }
+  });
+
+  it("throws on network error", async () => {
+    expect.assertions(2);
+
+    (window.fetch as jest.Mock).mockReturnValueOnce(
+      Promise.reject(new TypeError("Network error")),
+    );
+
+    try {
+      await trfetch<{}>(unusedRequestInfo);
+    } catch (e) {
+      expect(e).toBeInstanceOf(TypeError);
+      expect(e.message).toBe("Network error");
+    }
+  });
+});

--- a/src/utils/tr-fetch.ts
+++ b/src/utils/tr-fetch.ts
@@ -1,0 +1,54 @@
+import { APIError } from "../errors/APIError";
+
+/*
+ * Copyright 2019 Transposit Corporation. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * trfetch() is a thin-wrapper around native fetch().
+ * It treats non-2XX responses as failures.
+ * It assumes response bodies should be parsed a JSON.
+ */
+export function trfetch<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
+  return fetch(input, init).then((response: Response) => {
+    if (response.ok) {
+      return response.json().then(
+        x => x as T,
+        () => {
+          throw makeInternalError(response);
+        },
+      );
+    } else {
+      return response.json().then(
+        (body: any) => {
+          if (typeof body.message === "string") {
+            throw new APIError(body.message, response);
+          }
+          throw makeInternalError(response);
+        },
+        () => {
+          throw makeInternalError(response);
+        },
+      );
+    }
+  });
+}
+
+function makeInternalError(response: Response): APIError {
+  return new APIError(
+    "An internal error occurred. Try this operation again.",
+    response,
+  );
+}

--- a/src/utils/tr-fetch.ts
+++ b/src/utils/tr-fetch.ts
@@ -19,7 +19,7 @@ import { APIError } from "../errors/APIError";
 /**
  * trfetch() is a thin-wrapper around native fetch().
  * It treats non-2XX responses as failures.
- * It assumes response bodies should be parsed a JSON.
+ * It assumes response bodies should be parsed as JSON.
  */
 export function trfetch<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
   return fetch(input, init).then((response: Response) => {

--- a/src/utils/tr-fetch.ts
+++ b/src/utils/tr-fetch.ts
@@ -46,9 +46,10 @@ export function trfetch<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
   });
 }
 
+// @VisibleForTesting
+export const INTERNAL_ERROR_MESSAGE: string =
+  "API call failed in an unexpected way. Try again.";
+
 function makeInternalError(response: Response): APIError {
-  return new APIError(
-    "API call failed in an unexpected way. Try this operation again.",
-    response,
-  );
+  return new APIError(INTERNAL_ERROR_MESSAGE, response);
 }

--- a/src/utils/tr-fetch.ts
+++ b/src/utils/tr-fetch.ts
@@ -48,7 +48,7 @@ export function trfetch<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
 
 function makeInternalError(response: Response): APIError {
   return new APIError(
-    "An internal error occurred. Try this operation again.",
+    "API call failed in an unexpected way. Try this operation again.",
     response,
   );
 }

--- a/src/utils/tr-fetch.ts
+++ b/src/utils/tr-fetch.ts
@@ -1,5 +1,3 @@
-import { APIError } from "../errors/APIError";
-
 /*
  * Copyright 2019 Transposit Corporation. All Rights Reserved.
  *
@@ -15,6 +13,8 @@ import { APIError } from "../errors/APIError";
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import { APIError } from "../errors/APIError";
 
 /**
  * trfetch() is a thin-wrapper around native fetch().


### PR DESCRIPTION
This introduces the error model we discussed. All logical errors are `SDKError`s. All non-2XX fetch responses are `APIError`s. If there is a user-visible error message, it's in the `e.message` field. If not, a generic message indicating an internal error is displayed.

The goals of this work include:
- Making sure that errors are easily debuggable for developers if they console.log errors.
- Making sure that errors are easily debuggable for Transposit engineers if this output is included in a support ticket.
- Standardizing our error format so that it's easy to augment the SDK code in a consistent way.

Here's the user-visible and internal errors when console.logged:
![internal-error](https://user-images.githubusercontent.com/213565/65896199-a751ce80-e361-11e9-93ea-d62b3837b65a.png)
![uv-error](https://user-images.githubusercontent.com/213565/65896200-a9b42880-e361-11e9-8cf3-ab09f5f54ac0.png)

I have notes to file tickets for:
- Write up an SDK style guide for engineers making changes in the future
- Potentially add static checks that disallow throwing the raw Error type.