### PR TITLE
Add package options to debug tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "jest": "JEST_JUNIT_OUTPUT=\"./target/surefire-reports/client-sdk-test-results.xml\" jest",
     "jest:ci": "yarn run jest --ci --runInBand",
     "jest:watch": "yarn run jest --watch",
+    "jest:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
+    "jest:inspect": "node inspect node_modules/.bin/jest --runInBand",
     "prettier:check": "prettier --list-different 'src/**/*.ts'",
     "prettier:fix": "prettier 'src/**/*.ts' --write",
     "tslint": "tslint -p tsconfig.json",


### PR DESCRIPTION
Add jest:inspect and jest:debug as ways to run tests with a debugger to
investiage test issues.

`yarn run jest:inspect` will open the `node inspect` debugger inline in
the console.

`yarn run jest:debug` will run the tests and cause them to wait for an
external debugger to attach, such as the Chrome dedicated DevTools for
Node, accessible in chrome at chrome://inspect.