### PR TITLE
TR-4932 Add support for stash operations

### DIFF
--- a/src/Stash.ts
+++ b/src/Stash.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Transposit Corporation. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Transposit } from ".";
+
+export class Stash {
+  private transposit: Transposit;
+  constructor(transposit: Transposit) {
+    this.transposit = transposit;
+  }
+
+  async listKeys(): Promise<string[]> {
+    return this.transposit.makeCallJson<string[]>("GET", "/api/v1/stash/keys");
+  }
+
+  async get(key: string): Promise<any> {
+    const queryParams = { keyName: key };
+    return await this.transposit.makeCallJson<any>(
+      "GET",
+      "/api/v1/stash/value",
+      { queryParams },
+    );
+  }
+
+  async put(key: string, value: any): Promise<void> {
+    const queryParams = { keyName: key };
+    await this.transposit.makeCall("POST", "/api/v1/stash/value", {
+      queryParams,
+      body: value,
+    });
+    return;
+  }
+
+  async remove(key: string): Promise<void> {
+    const queryParams = { keyName: key };
+    await this.transposit.makeCall("DELETE", "/api/v1/stash/value", {
+      queryParams,
+    });
+    return;
+  }
+}

--- a/src/Stash.ts
+++ b/src/Stash.ts
@@ -41,6 +41,5 @@ export class Stash {
       queryParams,
       body: value,
     });
-    return;
   }
 }

--- a/src/Stash.ts
+++ b/src/Stash.ts
@@ -43,12 +43,4 @@ export class Stash {
     });
     return;
   }
-
-  async remove(key: string): Promise<void> {
-    const queryParams = { keyName: key };
-    await this.transposit.makeCall("DELETE", "/api/v1/stash/value", {
-      queryParams,
-    });
-    return;
-  }
 }

--- a/src/Transposit.ts
+++ b/src/Transposit.ts
@@ -211,9 +211,9 @@ export class Transposit {
 }
 
 interface HttpParams {
-  queryParams?: any;
   body?: any;
-  headers?: any;
+  headers?: { [s: string]: string };
+  queryParams?: { [s: string]: string };
 }
 
 export interface SignInSuccess {

--- a/src/Transposit.ts
+++ b/src/Transposit.ts
@@ -175,7 +175,7 @@ export class Transposit {
     path: string,
     { queryParams, body, headers }: HttpParams = {},
   ): Promise<Response> {
-    if (headers == null) {
+    if (!headers) {
       headers = {
         "Content-Type": "application/json",
       };

--- a/src/__tests__/Transposit.test.ts
+++ b/src/__tests__/Transposit.test.ts
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2018, 2019 Transposit Corporation. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -357,5 +357,115 @@ describe("Transposit", () => {
       expect(e).toBeInstanceOf(APIError);
       expect(e.message).toEqual(INTERNAL_ERROR_MESSAGE);
     }
+  });
+
+  it("deserializes good json in 2XX response", async () => {
+    expect.assertions(1);
+
+    const expected = { everything: "is", a: "okay!" };
+    (window.fetch as jest.Mock).mockReturnValueOnce(
+      Promise.resolve(new Response(JSON.stringify(expected), { status: 200 })),
+    );
+
+    const transposit = new Transposit(BACKEND_ORIGIN);
+    const actual = await transposit.makeCallJson<{}>("GET", "/endpoint");
+
+    expect(actual).toEqual(expected);
+  });
+
+  it("invalid json throws error", async () => {
+    expect.assertions(1);
+
+    const response = new Response("totaljunk", { status: 200 });
+    (window.fetch as jest.Mock).mockReturnValueOnce(Promise.resolve(response));
+
+    const transposit = new Transposit(BACKEND_ORIGIN);
+    return expect(
+      transposit.makeCallJson<{}>("GET", "/endpoint"),
+    ).rejects.toThrow(new APIError("Failed to read response body", response));
+  });
+
+  it("stash get sends correct request", async () => {
+    expect.assertions(2);
+    const expected = "someString";
+    const response = new Response('"someString"');
+
+    (window.fetch as jest.Mock).mockReturnValueOnce(Promise.resolve(response));
+    const transposit = new Transposit(BACKEND_ORIGIN);
+
+    const actual = await transposit.stash.get("key");
+
+    expect(actual).toBe(expected);
+    expect(window.fetch as jest.Mock).toHaveBeenCalledWith(
+      "https://arbys-beef-xyz12.transposit.io/api/v1/stash/value?keyName=key",
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+  });
+
+  it("stash listKeys sends correct request", async () => {
+    expect.assertions(2);
+    const expected = ["a", "b", "c"];
+    const response = new Response(`["a", "b", "c"]`);
+
+    (window.fetch as jest.Mock).mockReturnValueOnce(Promise.resolve(response));
+    const transposit = new Transposit(BACKEND_ORIGIN);
+
+    const actual = await transposit.stash.listKeys();
+
+    expect(actual).toEqual(expected);
+    expect(window.fetch as jest.Mock).toHaveBeenCalledWith(
+      "https://arbys-beef-xyz12.transposit.io/api/v1/stash/keys",
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+  });
+
+  it("stash put sends correct request", async () => {
+    expect.assertions(1);
+    const response = new Response("");
+
+    (window.fetch as jest.Mock).mockReturnValueOnce(Promise.resolve(response));
+    const transposit = new Transposit(BACKEND_ORIGIN);
+
+    await transposit.stash.put("key", "value");
+    expect(window.fetch as jest.Mock).toHaveBeenCalledWith(
+      "https://arbys-beef-xyz12.transposit.io/api/v1/stash/value?keyName=key",
+      {
+        method: "POST",
+        body: `"value"`,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+  });
+
+  it("stash remove sends correct request", async () => {
+    expect.assertions(1);
+    const response = new Response("");
+
+    (window.fetch as jest.Mock).mockReturnValueOnce(Promise.resolve(response));
+    const transposit = new Transposit(BACKEND_ORIGIN);
+
+    await transposit.stash.remove("key");
+
+    expect(window.fetch as jest.Mock).toHaveBeenCalledWith(
+      "https://arbys-beef-xyz12.transposit.io/api/v1/stash/value?keyName=key",
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
   });
 });

--- a/src/__tests__/Transposit.test.ts
+++ b/src/__tests__/Transposit.test.ts
@@ -385,67 +385,75 @@ describe("Transposit", () => {
     ).rejects.toThrow(new APIError("Failed to read response body", response));
   });
 
-  it("stash get sends correct request", async () => {
-    expect.assertions(2);
-    const expected = "someString";
-    const response = new Response('"someString"');
+  describe("stash", () => {
+    it("stash get sends correct request", async () => {
+      expect.assertions(2);
+      const expected = "someString";
+      const response = new Response('"someString"');
 
-    (window.fetch as jest.Mock).mockReturnValueOnce(Promise.resolve(response));
-    const transposit = new Transposit(BACKEND_ORIGIN);
+      (window.fetch as jest.Mock).mockReturnValueOnce(
+        Promise.resolve(response),
+      );
+      const transposit = new Transposit(BACKEND_ORIGIN);
 
-    const actual = await transposit.stash.get("key");
+      const actual = await transposit.stash.get("key");
 
-    expect(actual).toBe(expected);
-    expect(window.fetch as jest.Mock).toHaveBeenCalledWith(
-      "https://arbys-beef-xyz12.transposit.io/api/v1/stash/value?keyName=key",
-      {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
+      expect(actual).toBe(expected);
+      expect(window.fetch as jest.Mock).toHaveBeenCalledWith(
+        "https://arbys-beef-xyz12.transposit.io/api/v1/stash/value?keyName=key",
+        {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+          },
         },
-      },
-    );
-  });
+      );
+    });
 
-  it("stash listKeys sends correct request", async () => {
-    expect.assertions(2);
-    const expected = ["a", "b", "c"];
-    const response = new Response(`["a", "b", "c"]`);
+    it("stash listKeys sends correct request", async () => {
+      expect.assertions(2);
+      const expected = ["a", "b", "c"];
+      const response = new Response(`["a", "b", "c"]`);
 
-    (window.fetch as jest.Mock).mockReturnValueOnce(Promise.resolve(response));
-    const transposit = new Transposit(BACKEND_ORIGIN);
+      (window.fetch as jest.Mock).mockReturnValueOnce(
+        Promise.resolve(response),
+      );
+      const transposit = new Transposit(BACKEND_ORIGIN);
 
-    const actual = await transposit.stash.listKeys();
+      const actual = await transposit.stash.listKeys();
 
-    expect(actual).toEqual(expected);
-    expect(window.fetch as jest.Mock).toHaveBeenCalledWith(
-      "https://arbys-beef-xyz12.transposit.io/api/v1/stash/keys",
-      {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
+      expect(actual).toEqual(expected);
+      expect(window.fetch as jest.Mock).toHaveBeenCalledWith(
+        "https://arbys-beef-xyz12.transposit.io/api/v1/stash/keys",
+        {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+          },
         },
-      },
-    );
-  });
+      );
+    });
 
-  it("stash put sends correct request", async () => {
-    expect.assertions(1);
-    const response = new Response("");
+    it("stash put sends correct request", async () => {
+      expect.assertions(1);
+      const response = new Response("");
 
-    (window.fetch as jest.Mock).mockReturnValueOnce(Promise.resolve(response));
-    const transposit = new Transposit(BACKEND_ORIGIN);
+      (window.fetch as jest.Mock).mockReturnValueOnce(
+        Promise.resolve(response),
+      );
+      const transposit = new Transposit(BACKEND_ORIGIN);
 
-    await transposit.stash.put("key", "value");
-    expect(window.fetch as jest.Mock).toHaveBeenCalledWith(
-      "https://arbys-beef-xyz12.transposit.io/api/v1/stash/value?keyName=key",
-      {
-        method: "POST",
-        body: `"value"`,
-        headers: {
-          "Content-Type": "application/json",
+      await transposit.stash.put("key", "value");
+      expect(window.fetch as jest.Mock).toHaveBeenCalledWith(
+        "https://arbys-beef-xyz12.transposit.io/api/v1/stash/value?keyName=key",
+        {
+          method: "POST",
+          body: `"value"`,
+          headers: {
+            "Content-Type": "application/json",
+          },
         },
-      },
-    );
+      );
+    });
   });
 });

--- a/src/__tests__/Transposit.test.ts
+++ b/src/__tests__/Transposit.test.ts
@@ -448,24 +448,4 @@ describe("Transposit", () => {
       },
     );
   });
-
-  it("stash remove sends correct request", async () => {
-    expect.assertions(1);
-    const response = new Response("");
-
-    (window.fetch as jest.Mock).mockReturnValueOnce(Promise.resolve(response));
-    const transposit = new Transposit(BACKEND_ORIGIN);
-
-    await transposit.stash.remove("key");
-
-    expect(window.fetch as jest.Mock).toHaveBeenCalledWith(
-      "https://arbys-beef-xyz12.transposit.io/api/v1/stash/value?keyName=key",
-      {
-        method: "DELETE",
-        headers: {
-          "Content-Type": "application/json",
-        },
-      },
-    );
-  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,4 +16,5 @@
 
 export * from "./EndRequestLog";
 export * from "./Transposit";
+export * from "./Stash";
 export { User } from "./signin/user";

--- a/src/utils/__tests__/tr-fetch.test.ts
+++ b/src/utils/__tests__/tr-fetch.test.ts
@@ -27,38 +27,29 @@ describe("tr-fetch", () => {
   it("deserializes good json in 2XX response", async () => {
     expect.assertions(1);
 
-    const expected: {} = { everything: "is", a: "okay!" };
+    const body: {} = { everything: "is", a: "okay!" };
+    const expected = new Response(JSON.stringify(body), {
+      status: 200,
+    });
 
-    (window.fetch as jest.Mock).mockReturnValueOnce(
-      Promise.resolve(
-        new Response(JSON.stringify(expected), {
-          status: 200,
-        }),
-      ),
-    );
+    (window.fetch as jest.Mock).mockReturnValueOnce(Promise.resolve(expected));
 
-    const actual = await trfetch<{}>(unusedRequestInfo);
+    const actual = await trfetch(unusedRequestInfo);
 
     expect(actual).toEqual(expected);
   });
 
-  it("throws on bad json in 2XX response", async () => {
-    expect.assertions(2);
+  it("returns with bad json in 2XX response", async () => {
+    expect.assertions(1);
 
-    (window.fetch as jest.Mock).mockReturnValueOnce(
-      Promise.resolve(
-        new Response("totaljunk", {
-          status: 200,
-        }),
-      ),
-    );
+    const expected = new Response("totaljunk", {
+      status: 200,
+    });
 
-    try {
-      await trfetch<{}>(unusedRequestInfo);
-    } catch (e) {
-      expect(e).toBeInstanceOf(APIError);
-      expect(e.message).toBe(INTERNAL_ERROR_MESSAGE);
-    }
+    (window.fetch as jest.Mock).mockReturnValueOnce(Promise.resolve(expected));
+
+    const actual = await trfetch(unusedRequestInfo);
+    expect(actual).toEqual(expected);
   });
 
   it("throws on user-visible error in 4XX response", async () => {
@@ -76,7 +67,7 @@ describe("tr-fetch", () => {
     );
 
     try {
-      await trfetch<{}>(unusedRequestInfo);
+      await trfetch(unusedRequestInfo);
     } catch (e) {
       expect(e).toBeInstanceOf(APIError);
       expect(e.message).toBe("dance your face off");
@@ -95,7 +86,7 @@ describe("tr-fetch", () => {
     );
 
     try {
-      await trfetch<{}>(unusedRequestInfo);
+      await trfetch(unusedRequestInfo);
     } catch (e) {
       expect(e).toBeInstanceOf(APIError);
       expect(e.message).toBe(INTERNAL_ERROR_MESSAGE);
@@ -114,7 +105,7 @@ describe("tr-fetch", () => {
     );
 
     try {
-      await trfetch<{}>(unusedRequestInfo);
+      await trfetch(unusedRequestInfo);
     } catch (e) {
       expect(e).toBeInstanceOf(APIError);
       expect(e.message).toBe(INTERNAL_ERROR_MESSAGE);
@@ -129,7 +120,7 @@ describe("tr-fetch", () => {
     );
 
     try {
-      await trfetch<{}>(unusedRequestInfo);
+      await trfetch(unusedRequestInfo);
     } catch (e) {
       expect(e).toBeInstanceOf(TypeError);
       expect(e.message).toBe("Network error");

--- a/src/utils/tr-fetch.ts
+++ b/src/utils/tr-fetch.ts
@@ -29,17 +29,17 @@ export async function trfetch(
   if (response.ok) {
     return response;
   } else {
-    const error = await response.json().then(
-      (body: any) => {
-        if (typeof body.message === "string") {
-          return new APIError(body.message, response);
-        }
-        return makeInternalError(response);
-      },
-      () => {
-        return makeInternalError(response);
-      },
-    );
+    let error;
+    try {
+      const body = await response.json();
+      if (typeof body.message === "string") {
+        error = new APIError(body.message, response);
+      } else {
+        error = makeInternalError(response);
+      }
+    } catch (e) {
+      error = makeInternalError(response);
+    }
     throw error;
   }
 }


### PR DESCRIPTION
Add a Stash object with operations mirroring stash functionality when
running operations directly.

Separating into a stash object rather than just adding methods like
getStash() hides clutter when looking at documentation or using code
completion tools.

Created KeyValueStore interfaces in preparation for adding env and
user_settings, which have similar features and which people may want to
handle generically.

Includes a refactor of the code used to make HTTP calls to support
typed returns, empty returns, query parameters, etc.

Continuation of pull request based on 1.X