### PR TITLE
TR-4933 Add support for env.get

### DIFF
--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, 2019 Transposit Corporation. All Rights Reserved.
+ * Copyright 2019 Transposit Corporation. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,18 @@
  * limitations under the License.
  */
 
-export * from "./EndRequestLog";
-export * from "./Environment";
-export * from "./Transposit";
-export * from "./Stash";
-export { User } from "./signin/user";
+import { Transposit } from ".";
+
+export class Environment {
+  private transposit: Transposit;
+  constructor(transposit: Transposit) {
+    this.transposit = transposit;
+  }
+
+  async get<T>(key: string): Promise<T> {
+    const queryParams = { keyName: key };
+    return await this.transposit.makeCallJson<T>("GET", "/api/v1/env/value", {
+      queryParams,
+    });
+  }
+}

--- a/src/Transposit.ts
+++ b/src/Transposit.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { EndRequestLog, Stash } from ".";
+import { EndRequestLog, Environment, Stash } from ".";
 import { APIError } from "./errors/APIError";
 import { SDKError } from "./errors/SDKError";
 import { popCodeVerifier, pushCodeVerifier } from "./signin/pkce-helper";
@@ -137,6 +137,10 @@ export class Transposit {
 
   get stash() {
     return new Stash(this);
+  }
+
+  get env() {
+    return new Environment(this);
   }
 
   async loadUser(): Promise<User> {

--- a/src/__tests__/Transposit.test.ts
+++ b/src/__tests__/Transposit.test.ts
@@ -456,4 +456,30 @@ describe("Transposit", () => {
       );
     });
   });
+
+  describe("env", () => {
+    it("env get sends correct request", async () => {
+      expect.assertions(2);
+      const expected = "someString";
+      const response = new Response('"someString"');
+
+      (window.fetch as jest.Mock).mockReturnValueOnce(
+        Promise.resolve(response),
+      );
+      const transposit = new Transposit(BACKEND_ORIGIN);
+
+      const actual = await transposit.env.get<string>("key");
+
+      expect(actual).toBe(expected);
+      expect(window.fetch as jest.Mock).toHaveBeenCalledWith(
+        "https://arbys-beef-xyz12.transposit.io/api/v1/env/value?keyName=key",
+        {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        },
+      );
+    });
+  });
 });


### PR DESCRIPTION
Add an Environment object that can fetch values from the app's
environment, mirroring the env environment available when
running an operation.

Does not include env.getBuiltin() because we don't believe this
functionality to have much use when _not_ running inside an
operation.