### PR TITLE
TR-4934 Add support for userSetting operations

### DIFF
--- a/src/Transposit.ts
+++ b/src/Transposit.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { EndRequestLog, Stash } from ".";
+import { EndRequestLog, Stash, UserSetting } from ".";
 import { APIError } from "./errors/APIError";
 import { SDKError } from "./errors/SDKError";
 import { popCodeVerifier, pushCodeVerifier } from "./signin/pkce-helper";
@@ -137,6 +137,10 @@ export class Transposit {
 
   get stash() {
     return new Stash(this);
+  }
+
+  get userSetting() {
+    return new UserSetting(this);
   }
 
   async loadUser(): Promise<User> {

--- a/src/Transposit.ts
+++ b/src/Transposit.ts
@@ -142,11 +142,11 @@ export class Transposit {
   get env() {
     return new Environment(this);
   }
-  
+
   get userSetting() {
     return new UserSetting(this);
+  }
 
-    
   async loadUser(): Promise<User> {
     this.assertIsSignedIn();
 

--- a/src/UserSetting.ts
+++ b/src/UserSetting.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Transposit Corporation. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Transposit } from ".";
+
+export class UserSetting {
+  private transposit: Transposit;
+  constructor(transposit: Transposit) {
+    this.transposit = transposit;
+  }
+
+  async get(key: string): Promise<any> {
+    const queryParams = { keyName: key };
+    return await this.transposit.makeCallJson<any>(
+      "GET",
+      "/api/v1/user_setting/value",
+      { queryParams },
+    );
+  }
+
+  async put(key: string, value: any): Promise<void> {
+    const queryParams = { keyName: key };
+    await this.transposit.makeCall("POST", "/api/v1/user_setting/value", {
+      queryParams,
+      body: value,
+    });
+  }
+}

--- a/src/UserSetting.ts
+++ b/src/UserSetting.ts
@@ -22,9 +22,9 @@ export class UserSetting {
     this.transposit = transposit;
   }
 
-  async get(key: string): Promise<any> {
+  async get<T>(key: string): Promise<T> {
     const queryParams = { keyName: key };
-    return await this.transposit.makeCallJson<any>(
+    return await this.transposit.makeCallJson<T>(
       "GET",
       "/api/v1/user_setting/value",
       { queryParams },

--- a/src/__tests__/Transposit.test.ts
+++ b/src/__tests__/Transposit.test.ts
@@ -456,4 +456,52 @@ describe("Transposit", () => {
       );
     });
   });
+
+  describe("userSetting", () => {
+    it("userSetting get sends correct request", async () => {
+      expect.assertions(2);
+      const expected = "someString";
+      const response = new Response('"someString"');
+
+      (window.fetch as jest.Mock).mockReturnValueOnce(
+        Promise.resolve(response),
+      );
+      const transposit = new Transposit(BACKEND_ORIGIN);
+
+      const actual = await transposit.userSetting.get("key");
+
+      expect(actual).toBe(expected);
+      expect(window.fetch as jest.Mock).toHaveBeenCalledWith(
+        "https://arbys-beef-xyz12.transposit.io/api/v1/user_setting/value?keyName=key",
+        {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        },
+      );
+    });
+
+    it("userSetting put sends correct request", async () => {
+      expect.assertions(1);
+      const response = new Response("");
+
+      (window.fetch as jest.Mock).mockReturnValueOnce(
+        Promise.resolve(response),
+      );
+      const transposit = new Transposit(BACKEND_ORIGIN);
+
+      await transposit.userSetting.put("key", "value");
+      expect(window.fetch as jest.Mock).toHaveBeenCalledWith(
+        "https://arbys-beef-xyz12.transposit.io/api/v1/user_setting/value?keyName=key",
+        {
+          method: "POST",
+          body: `"value"`,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        },
+      );
+    });
+  });
 });

--- a/src/__tests__/Transposit.test.ts
+++ b/src/__tests__/Transposit.test.ts
@@ -493,7 +493,7 @@ describe("Transposit", () => {
         Promise.resolve(response),
       );
       const transposit = new Transposit(BACKEND_ORIGIN);
-      const actual = await transposit.userSetting.get("key");
+      const actual = await transposit.userSetting.get<string>("key");
 
       expect(actual).toBe(expected);
       expect(window.fetch as jest.Mock).toHaveBeenCalledWith(

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,4 +17,5 @@
 export * from "./EndRequestLog";
 export * from "./Transposit";
 export * from "./Stash";
+export * from "./UserSetting";
 export { User } from "./signin/user";


### PR DESCRIPTION
Add a userSetting object with methods mirroring the userSetting
functionality available within an operation.

Accesses or modifies settings of the current logged-in user.