### PR TITLE
TR-5032 Refactor run operation reponses

### DIFF
--- a/src/Operation.ts
+++ b/src/Operation.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018, 2019 Transposit Corporation. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { EndRequestLog } from "./EndRequestLog";
+import { APIError } from "./errors/APIError";
+
+export class OperationError extends APIError {
+  requestId: string;
+  constructor(log: EndRequestLog, response: Response) {
+    const exceptionLog = log.result.exceptionLog;
+    let message;
+    if (!exceptionLog || !exceptionLog.message) {
+      message = "A problem occurred when processing this operation.";
+    } else {
+      message = exceptionLog.message;
+    }
+    super(message, response);
+    this.requestId = log.requestId;
+    // https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    Object.setPrototypeOf(this, OperationError.prototype);
+  }
+}
+
+export interface OperationResponse<T> {
+  results: T[];
+  requestId: string;
+  value: T;
+}

--- a/src/Transposit.ts
+++ b/src/Transposit.ts
@@ -14,8 +14,13 @@
  * limitations under the License.
  */
 
-
-import { Environment, OperationError, OperationResponse, Stash, UserSetting } from ".";
+import {
+  Environment,
+  OperationError,
+  OperationResponse,
+  Stash,
+  UserSetting,
+} from ".";
 import { EndRequestLog } from "./EndRequestLog";
 import { APIError } from "./errors/APIError";
 import { SDKError } from "./errors/SDKError";

--- a/src/Transposit.ts
+++ b/src/Transposit.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { EndRequestLog, Environment, Stash } from ".";
+import { Environment, OperationError, OperationResponse, Stash } from ".";
+import { EndRequestLog } from "./EndRequestLog";
 import { APIError } from "./errors/APIError";
 import { SDKError } from "./errors/SDKError";
 import { popCodeVerifier, pushCodeVerifier } from "./signin/pkce-helper";
@@ -149,15 +150,20 @@ export class Transposit {
     return await this.makeCallJson<User>("GET", "/api/v1/user");
   }
 
-  async run(
+  async run<T>(
     operationId: string,
     parameters: OperationParameters = {},
-  ): Promise<EndRequestLog> {
-    return this.makeCallJson<EndRequestLog>(
+  ): Promise<OperationResponse<T>> {
+    const response = await this.makeCall(
       "POST",
       `/api/v1/execute/${operationId}`,
       { body: { parameters } },
     );
+    const log = await extractJson<EndRequestLog>(response);
+    if (log.status !== "SUCCESS") {
+      throw new OperationError(log, response);
+    }
+    return new EndRequestLogResponse<T>(log, response);
   }
 
   async makeCallJson<T>(
@@ -166,12 +172,7 @@ export class Transposit {
     httpParams: HttpParams = {},
   ): Promise<T> {
     const response = await this.makeCall(method, path, httpParams);
-    return response.json().then(
-      x => x,
-      () => {
-        throw new APIError("Failed to read response body", response);
-      },
-    );
+    return extractJson<T>(response);
   }
 
   async makeCall(
@@ -214,6 +215,15 @@ export class Transposit {
   }
 }
 
+function extractJson<T>(response: Response): Promise<T> {
+  return response.json().then(
+    x => x,
+    () => {
+      throw new APIError("Failed to read response body", response);
+    },
+  );
+}
+
 interface HttpParams {
   body?: any;
   headers?: { [s: string]: string };
@@ -226,4 +236,27 @@ export interface SignInSuccess {
 
 export interface OperationParameters {
   [paramName: string]: string;
+}
+
+class EndRequestLogResponse<T> implements OperationResponse<T> {
+  results: T[];
+  requestId: string;
+  constructor(log: EndRequestLog, response: Response) {
+    this.requestId = log.requestId;
+    const logResults = log.result.results;
+    if (!logResults) {
+      throw new APIError(
+        "API returned an unexpected response schema",
+        response,
+      );
+    }
+    this.results = logResults;
+  }
+
+  get value(): T {
+    if (this.results.length === 0) {
+      throw new Error("Operation did not return a value");
+    }
+    return this.results[0];
+  }
 }

--- a/src/__tests__/Transposit.test.ts
+++ b/src/__tests__/Transposit.test.ts
@@ -371,7 +371,12 @@ describe("Transposit", () => {
       }
     });
 
-    const badStatuses = ["ERROR", "CANCELLED", "TIMEOUT"];
+    const badStatuses = [
+      "ERROR",
+      "CANCELLED",
+      "TIMEOUT",
+      "RESOURCELIMITEXCEEDED",
+    ];
     badStatuses.forEach(status => {
       it(`run with ${status} throws OperationError`, async () => {
         expect.assertions(4);

--- a/src/__tests__/Transposit.test.ts
+++ b/src/__tests__/Transposit.test.ts
@@ -371,8 +371,8 @@ describe("Transposit", () => {
       }
     });
 
-    let bad_statuses = ["ERROR", "CANCELLED", "TIMEOUT"];
-    bad_statuses.forEach(function (status) {
+    const badStatuses = ["ERROR", "CANCELLED", "TIMEOUT"];
+    badStatuses.forEach(status => {
       it(`run with ${status} throws OperationError`, async () => {
         expect.assertions(4);
 
@@ -381,7 +381,7 @@ describe("Transposit", () => {
 
         const response: Response = new Response(
           JSON.stringify({
-            status: status,
+            status,
             requestId: "12345",
             result: {
               exceptionLog: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-// export * from "./EndRequestLog";
 export * from "./Environment";
 export * from "./Operation";
 export * from "./Transposit";

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-export * from "./EndRequestLog";
+// export * from "./EndRequestLog";
 export * from "./Environment";
+export * from "./Operation";
 export * from "./Transposit";
 export * from "./Stash";
 export { User } from "./signin/user";


### PR DESCRIPTION
Change the return type of Transposit.run to simplify it.

Return value now contains just the requestId and the array of values
returned. It also includes a convenience getter for a single value if
the called operation should only return a value. (Even if an operation
returns a non-array, we wrap the result in an array in the response.)

Non-successful operations throw an exception, so result only needs to
handle successful cases. Code that calls operations that might fail
should catch and handle these cases.

Add type parameterization to run function, so caller can declare the
expected form of the JSON response. In the future, we may limit type
parameterization to only allow values that one could represent as JSON,
but as of now we don't know how to do that correctly in TypeScript's
type-system.